### PR TITLE
Error Querying when "+" found in title

### DIFF
--- a/spice_api/helpers.py
+++ b/spice_api/helpers.py
@@ -33,7 +33,7 @@ import requests
 
 def get_query_url(medium, query):
     query = query.strip()
-    terms = query.replace(' ', '+')
+    terms = query.replace("+", "_").replace(' ', '+')
     if medium == tokens.Medium.ANIME:
         return constants.ANIME_QUERY_BASE + terms
     elif medium == tokens.Medium.MANGA:


### PR DESCRIPTION
The query would return an empty list when there is a "+" in the query. With a little experimentation, I found that if you replace it with a _ it works. 
Ex
https://myanimelist.net/api/anime/search.xml?q=A-Channel:+_A-Channel
and 
https://myanimelist.net/api/anime/search.xml?q=A-Channel:++A-Channel
As you can see, the first query correctly returns information on the anime, while the second one returns nothing.