### PR TITLE
Fix synopsis formatting errors and neat-ify it

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,6 +34,7 @@ setup(
     keywords = ['spice', 'MyAnimeList', 'API'], # arbitrary keywords
     install_requires = [
         'requests',
-        'beautifulsoup4'
+        'beautifulsoup4',
+        'lxml'
     ],
 )

--- a/spice_api/objects.py
+++ b/spice_api/objects.py
@@ -169,9 +169,10 @@ class Anime:
             self._synopsis = synopsis_val.text
            
         self._synopsis = self._synopsis.replace("<br />\r\n<br />\r\n","") #remove those nasty characters
-        if "(Source:" in self._synopsis: # if the source in synopsis
+        if "(Source:" in self._synopsis: 
             self._synopsis = self._synopsis.replace(self._synopsis[self._synopsis.index("(Source:"):],"") #delete everything from the source to the end
-        self._synopsis = self._synopsis.replace("[Written by MAL Rewrite]","")#delete MAL Rewrite token
+        while "[" in self._synopsis: # code to remove bbcodes also remove MAL Rewrite signatures due to "[]" pattern. 
+            self._synopsis = self._synopsis.replace(self._synopsis[self._synopsis.index("["):self._synopsis.index("]")],"")
         self._synopsis = html.unescape(self._synopsis) #replace html codes
         
         return self._synopsis
@@ -393,7 +394,8 @@ class Manga:
         self._synopsis = self._synopsis.replace("<br />\r\n<br />\r\n","") #remove those nasty characters
         if "(Source:" in self._synopsis: # if the source in synopsis
             self._synopsis = self._synopsis.replace(self._synopsis[self._synopsis.index("(Source:"):],"") #delete everything from the source to the end
-        self._synopsis = self._synopsis.replace("[Written by MAL Rewrite]","")#delete MAL Rewrite token
+        while "[" in self._synopsis: # code to remove bbcodes also remove MAL Rewrite signatures due to "[]" pattern. 
+            self._synopsis = self._synopsis.replace(self._synopsis[self._synopsis.index("["):self._synopsis.index("]")],"")
         self._synopsis = html.unescape(self._synopsis) #replace html codes
         
         return self._synopsis

--- a/spice_api/objects.py
+++ b/spice_api/objects.py
@@ -42,6 +42,7 @@ from . import constants
 from . import tokens
 import requests
 from bs4 import BeautifulSoup
+import html
 
 class Anime:
     """An object that encapsulates an Anime.
@@ -166,6 +167,13 @@ class Anime:
             if synopsis_val is None:
                 return None
             self._synopsis = synopsis_val.text
+           
+        self._synopsis = self._synopsis.replace("<br />\r\n<br />\r\n","") #remove those nasty characters
+        if "(Source:" in self._synopsis: # if the source in synopsis
+            self._synopsis = self._synopsis.replace(self._synopsis[self._synopsis.index("(Source:"):],"") #delete everything from the source to the end
+        self._synopsis = self._synopsis.replace("[Written by MAL Rewrite]","")#delete MAL Rewrite token
+        self._synopsis = html.unescape(self._synopsis) #replace html codes
+        
         return self._synopsis
 
     @property

--- a/spice_api/objects.py
+++ b/spice_api/objects.py
@@ -389,6 +389,13 @@ class Manga:
             if synopsis_val is None:
                 return None
             self._synopsis = synopsis_val.text
+        
+        self._synopsis = self._synopsis.replace("<br />\r\n<br />\r\n","") #remove those nasty characters
+        if "(Source:" in self._synopsis: # if the source in synopsis
+            self._synopsis = self._synopsis.replace(self._synopsis[self._synopsis.index("(Source:"):],"") #delete everything from the source to the end
+        self._synopsis = self._synopsis.replace("[Written by MAL Rewrite]","")#delete MAL Rewrite token
+        self._synopsis = html.unescape(self._synopsis) #replace html codes
+        
         return self._synopsis
 
     @property

--- a/spice_api/objects.py
+++ b/spice_api/objects.py
@@ -172,7 +172,7 @@ class Anime:
         if "(Source:" in self._synopsis: 
             self._synopsis = self._synopsis.replace(self._synopsis[self._synopsis.index("(Source:"):],"") #delete everything from the source to the end
         while "[" in self._synopsis: # code to remove bbcodes also remove MAL Rewrite signatures due to "[]" pattern. 
-            self._synopsis = self._synopsis.replace(self._synopsis[self._synopsis.index("["):self._synopsis.index("]")],"")
+            self._synopsis = self._synopsis.replace(self._synopsis[self._synopsis.index("["):self._synopsis.index("]")+1],"")
         self._synopsis = html.unescape(self._synopsis) #replace html codes
         
         return self._synopsis
@@ -395,7 +395,7 @@ class Manga:
         if "(Source:" in self._synopsis: # if the source in synopsis
             self._synopsis = self._synopsis.replace(self._synopsis[self._synopsis.index("(Source:"):],"") #delete everything from the source to the end
         while "[" in self._synopsis: # code to remove bbcodes also remove MAL Rewrite signatures due to "[]" pattern. 
-            self._synopsis = self._synopsis.replace(self._synopsis[self._synopsis.index("["):self._synopsis.index("]")],"")
+            self._synopsis = self._synopsis.replace(self._synopsis[self._synopsis.index("["):self._synopsis.index("]")+1],"")
         self._synopsis = html.unescape(self._synopsis) #replace html codes
         
         return self._synopsis


### PR DESCRIPTION
eshanmind back at it again!


When looking at anime synopsis, 3 errors become glaringly obvious

+ a nasty `<br />\r\n<br />\r\n` code is inserted every time there is a line break.
+ some characters like `—` and `'` get replaced with their html codes, `&mdash;`, and `&#039`
+ At the end of every synopsis there is sometimes a `[Written by MAL Rewrite]` or `(Source: ANN)` or something of the sort. This is perhaps a personal thing, but it would be cleaner if it wasn't there. 

_Bob the builder can we fix it?_
**I fixed it**


<sup>PS: please disregard the fact that the head branch is "sysopsis" instead of "synopsis" I just realized it along with the fact that i might be mentally handicapped</sup>


tuturuuu
~eshanmind
  