### PR TITLE
Make MediumList iterable

### DIFF
--- a/spice_api/objects.py
+++ b/spice_api/objects.py
@@ -497,6 +497,12 @@ class MediumList:
             raise ValueError(constants.INVALID_MEDIUM)
 
         self.load()
+        self.listIter = None
+        
+    def __iter__(self):
+        if self.listIter==None:
+            self.listIter=iter([item for s in [i[1] for i in self.medium_list.items()] for item in s])
+        return self.listIter
 
     def load(self):
         list_soup = self.raw_data


### PR DESCRIPTION
redo of the previous PR(#33). 

Small change to make medium_list an iterable class, I couldn't figure out a way to lazily return the next object, so I converted medium_list dictionary into a list and returned the iterator of that list.

To be at least a little considerate of the user's time, I wrote it so that if the user didn't actually want to iterate over the list, it doesn't actually do the calculations( also, it doesn't repeat the calculation if `__iter__()` is called twice).

Solves issue #32!